### PR TITLE
Make ping and version calls consistent with client connection configu…

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -3,12 +3,12 @@ module InfluxDB
     # rubocop:disable Metrics/AbcSize
     module Core
       def ping
-        get "/ping".freeze
+        url = URI::Generic.build(path: File.join(config.prefix, '/ping')).to_s
+        get url
       end
 
       def version
-        resp = get "/ping".freeze
-        resp.header['x-influxdb-version']
+        ping.header['x-influxdb-version']
       end
 
       # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Hello, I found that methods `ping` and `version` do not work correctly with some connection configuration (that uses `prefix` for client initialize method in my case). This PR fixes the issue.
